### PR TITLE
Add generic Main class in o.e.e.o.serviceregistry

### DIFF
--- a/projects/org.eclipse.ecf.osgi.serviceregistry.remoteservices/.classpath
+++ b/projects/org.eclipse.ecf.osgi.serviceregistry.remoteservices/.classpath
@@ -14,7 +14,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/gogo/org.apache.felix.gogo.shell_0.10.0.v201212101605.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/equinox/org.eclipse.osgi.services_3.4.0.v20140312-2051.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/ecf/core/org.eclipse.ecf.remoteservice.asyncproxy_1.0.100.v20150702-1411.jar"/>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/ecf/core/org.eclipse.ecf_3.8.0.v20160405-1820.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/ecf/core/org.eclipse.ecf.identity_3.7.0.v20160405-1820.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/ecf/core/org.eclipse.ecf.discovery_5.0.200.v20160405-1820.jar"/>

--- a/projects/org.eclipse.ecf.osgi.serviceregistry/src/org/eclipse/ecf/osgi/serviceregistry/launch/Main.java
+++ b/projects/org.eclipse.ecf.osgi.serviceregistry/src/org/eclipse/ecf/osgi/serviceregistry/launch/Main.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Composent, Inc. and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Composent, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.ecf.osgi.serviceregistry.launch;
+
+import java.util.ServiceLoader;
+
+import org.eclipse.ecf.osgi.serviceregistry.ServiceRegistryFactory;
+
+public class Main {
+
+	public static void main(String[] args) throws Exception {
+
+		ServiceLoader.load(ServiceRegistryFactory.class).iterator().next().newServiceRegistry(null);
+
+		Object w = new Object();
+		synchronized (w) {
+			// wait forever
+			try {
+				w.wait();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+}

--- a/projects/org.osgi.core.v6/.classpath
+++ b/projects/org.osgi.core.v6/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="osgi.core-6.0.0.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
I checked out the sources to get a better view on this project and the examples. The first thing I noticed when importing into Eclipse Neon were errors about non existing src folders in the build path. They shouldn't be there either because these projects are only wrappers around a jar. I therefore updated the build path for two projects.

Additionally I added the generic Main class from one of the examples to o.e.e.o.serviceregistry. I think a lot of people (like me) would create a simple Java project with that single Main class just to be able to start the framework with their bundles. Therefore it would be helpful if that simple generic Main class would be provided by the jar itself.

I understand that for consuming remote services you could already do some configuration in the Main, but a) for these cases a custom Main can be created and b) I think this could also be done in another bundle (e.g. in an Activator or a DS component). In both cases the effort to create a new project that produces a jar to start the framework would be fine.
